### PR TITLE
Add Content decoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SQL Database Vector Search Sample
 A repository that showcases the native VECTOR type in Azure SQL Database to perform embeddings and RAG with Azure OpenAI.
 
-The application is a Minimal API that exposes endpoints to load documents, generate embeddings and save them into the database as Vectors, and perform searches using Vector Search and RAG. Currently, only PDF files are supported. Vectors are saved and retrieved with Entity Framework Core using the [EFCore.SqlServer.VectorSearch](https://github.com/efcore/EfCore.SqlServer.VectorSearch) library. Embedding and Chat Completion are integrated with [Semantic Kernel](https://github.com/microsoft/semantic-kernel).
+The application is a Minimal API that exposes endpoints to load documents, generate embeddings and save them into the database as Vectors, and perform searches using Vector Search and RAG. Currently, PDF, DOCX and TXT files are supported. Vectors are saved and retrieved with Entity Framework Core using the [EFCore.SqlServer.VectorSearch](https://github.com/efcore/EfCore.SqlServer.VectorSearch) library. Embedding and Chat Completion are integrated with [Semantic Kernel](https://github.com/microsoft/semantic-kernel).
 
 > [!NOTE]
 > If you prefer to use straight SQL, check out the [sql branch](https://github.com/marcominerva/SqlDatabaseVectorSearch/tree/sql).
@@ -15,4 +15,4 @@ The application is a Minimal API that exposes endpoints to load documents, gener
   - You may need to update the size of the [`VECTOR`](https://github.com/marcominerva/SqlDatabaseVectorSearch/blob/master/Scripts.sql#L17) column to match the size of the embedding model. Currently, the maximum allowed value is 1998.
 - Open the [appsettings.json](https://github.com/marcominerva/SqlDatabaseVectorSearch/blob/master/SqlDatabaseVectorSearch/appsettings.json) file and set the connection string to the database and the other settings required by Azure OpenAI
   - If your embedding model supports shortening, like **text-embedding-3-small** and **text-embedding-3-large**, and you want to use this feature, you need to set the [`Dimensions`](https://github.com/marcominerva/SqlDatabaseVectorSearch/blob/master/SqlDatabaseVectorSearch/appsettings.json#L17) property to match the value you have used in the SQL script. If your model doesn't provide this feature, or do you want to use the default size, just leave the [`Dimensions`](https://github.com/marcominerva/SqlDatabaseVectorSearch/blob/master/SqlDatabaseVectorSearch/appsettings.json#L17) property to NULL. Keep in mind that **text-embedding-3-small** has a dimension of 1536, while **text-embedding-3-large** uses vectors with 3072 elements, so with this latter model it is mandatory to specify a value (that, as said, must be less or equal to 1998).
-- Run the application and start importing your PDF documents.
+- Run the application and start importing your documents.

--- a/SqlDatabaseVectorSearch/ContentDecoders/DocxContentDecoder.cs
+++ b/SqlDatabaseVectorSearch/ContentDecoders/DocxContentDecoder.cs
@@ -1,0 +1,61 @@
+﻿using System.Text;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+
+namespace SqlDatabaseVectorSearch.ContentDecoders;
+
+public class DocxContentDecoder : IContentDecoder
+{
+    public Task<string> DecodeAsync(Stream stream, string contentType)
+    {
+        // Open a Word document for read-only access.
+        using var document = WordprocessingDocument.Open(stream, false);
+
+        var body = document.MainDocumentPart?.Document.Body;
+        var content = new StringBuilder();
+
+        var paragraphs = body?.Descendants<Paragraph>() ?? [];
+        foreach (var p in paragraphs)
+        {
+            content.AppendLine(p.InnerText);
+        }
+
+        return Task.FromResult(content.ToString());
+
+        //foreach (var paragraph in body!.Elements<Paragraph>())
+        //{
+        //    foreach (var element in paragraph.Elements())
+        //    {
+        //        if (element is Run run)
+        //        {
+        //            DecodeTextFromRun(run);
+        //        }
+        //        else if (element is Hyperlink hyperlink)
+        //        {
+        //            foreach (var hyperlinkRun in hyperlink.Elements<Run>())
+        //            {
+        //                DecodeTextFromRun(hyperlinkRun);
+        //            }
+
+        //            //var hyperlinkUri = doc.MainDocumentPart.HyperlinkRelationships.FirstOrDefault(r => r.Id == hyperlink.Id)?.Uri;
+        //            //if (hyperlinkUri is not null)
+        //            //{
+        //            //    content.Append($" ({hyperlinkUri})");
+        //            //}
+        //        }
+        //    }
+
+        //    content.AppendLine(); // Preserve whitespace and blank lines.
+        //}
+
+        //return Task.FromResult(content.ToString());
+
+        //void DecodeTextFromRun(Run run)
+        //{
+        //    foreach (var text in run.Elements<Text>())
+        //    {
+        //        content.Append(text.Text);
+        //    }
+        //}
+    }
+}

--- a/SqlDatabaseVectorSearch/ContentDecoders/DocxContentDecoder.cs
+++ b/SqlDatabaseVectorSearch/ContentDecoders/DocxContentDecoder.cs
@@ -21,41 +21,5 @@ public class DocxContentDecoder : IContentDecoder
         }
 
         return Task.FromResult(content.ToString());
-
-        //foreach (var paragraph in body!.Elements<Paragraph>())
-        //{
-        //    foreach (var element in paragraph.Elements())
-        //    {
-        //        if (element is Run run)
-        //        {
-        //            DecodeTextFromRun(run);
-        //        }
-        //        else if (element is Hyperlink hyperlink)
-        //        {
-        //            foreach (var hyperlinkRun in hyperlink.Elements<Run>())
-        //            {
-        //                DecodeTextFromRun(hyperlinkRun);
-        //            }
-
-        //            //var hyperlinkUri = doc.MainDocumentPart.HyperlinkRelationships.FirstOrDefault(r => r.Id == hyperlink.Id)?.Uri;
-        //            //if (hyperlinkUri is not null)
-        //            //{
-        //            //    content.Append($" ({hyperlinkUri})");
-        //            //}
-        //        }
-        //    }
-
-        //    content.AppendLine(); // Preserve whitespace and blank lines.
-        //}
-
-        //return Task.FromResult(content.ToString());
-
-        //void DecodeTextFromRun(Run run)
-        //{
-        //    foreach (var text in run.Elements<Text>())
-        //    {
-        //        content.Append(text.Text);
-        //    }
-        //}
     }
 }

--- a/SqlDatabaseVectorSearch/ContentDecoders/IContentDecoder.cs
+++ b/SqlDatabaseVectorSearch/ContentDecoders/IContentDecoder.cs
@@ -1,0 +1,6 @@
+﻿namespace SqlDatabaseVectorSearch.ContentDecoders;
+
+public interface IContentDecoder
+{
+    Task<string> DecodeAsync(Stream stream, string contentType);
+}

--- a/SqlDatabaseVectorSearch/ContentDecoders/PdfContentDecoder.cs
+++ b/SqlDatabaseVectorSearch/ContentDecoders/PdfContentDecoder.cs
@@ -1,0 +1,24 @@
+﻿using System.Text;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
+
+namespace SqlDatabaseVectorSearch.ContentDecoders;
+
+public class PdfContentDecoder : IContentDecoder
+{
+    public Task<string> DecodeAsync(Stream stream, string contentType)
+    {
+        var content = new StringBuilder();
+
+        // Read the content of the PDF document.
+        using var pdfDocument = PdfDocument.Open(stream);
+
+        foreach (var page in pdfDocument.GetPages().Where(x => x is not null))
+        {
+            var pageContent = ContentOrderTextExtractor.GetText(page) ?? string.Empty;
+            content.AppendLine(pageContent);
+        }
+
+        return Task.FromResult(content.ToString());
+    }
+}

--- a/SqlDatabaseVectorSearch/ContentDecoders/TextContentDecoder.cs
+++ b/SqlDatabaseVectorSearch/ContentDecoders/TextContentDecoder.cs
@@ -1,0 +1,12 @@
+﻿namespace SqlDatabaseVectorSearch.ContentDecoders;
+
+public class TextContentDecoder : IContentDecoder
+{
+    public async Task<string> DecodeAsync(Stream stream, string contentType)
+    {
+        using var readStream = new StreamReader(stream);
+        var content = await readStream.ReadToEndAsync();
+
+        return content;
+    }
+}

--- a/SqlDatabaseVectorSearch/Services/VectorSearchService.cs
+++ b/SqlDatabaseVectorSearch/Services/VectorSearchService.cs
@@ -18,7 +18,7 @@ public class VectorSearchService(IServiceProvider serviceProvider, ApplicationDb
     public async Task<Guid> ImportAsync(Stream stream, string name, string contentType, Guid? documentId)
     {
         // Extract the contents of the file.
-        var decoder = serviceProvider.GetRequiredKeyedService<IContentDecoder>(contentType);
+        var decoder = serviceProvider.GetKeyedService<IContentDecoder>(contentType) ?? throw new NotSupportedException($"Content type '{contentType}' is not supported.");
         var content = await decoder.DecodeAsync(stream, contentType);
 
         await dbContext.Database.BeginTransactionAsync();

--- a/SqlDatabaseVectorSearch/SqlDatabaseVectorSearch.csproj
+++ b/SqlDatabaseVectorSearch/SqlDatabaseVectorSearch.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Microsoft.ML.Tokenizers" Version="1.0.1" />
         <PackageReference Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
         <PackageReference Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.1" />
-        <PackageReference Include="Microsoft.SemanticKernel" Version="1.34.0" />
+        <PackageReference Include="Microsoft.SemanticKernel" Version="1.35.0" />
         <PackageReference Include="MinimalHelpers.OpenApi" Version="2.1.3" />
         <PackageReference Include="PdfPig" Version="0.1.9" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />

--- a/SqlDatabaseVectorSearch/SqlDatabaseVectorSearch.csproj
+++ b/SqlDatabaseVectorSearch/SqlDatabaseVectorSearch.csproj
@@ -8,6 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+        <PackageReference Include="DocumentFormat.OpenXml" Version="3.2.0" />
         <PackageReference Include="EFCore.SqlServer.VectorSearch" Version="9.0.0-preview.2" />
         <PackageReference Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />


### PR DESCRIPTION
This pull request introduces several significant changes to the `SqlDatabaseVectorSearch` project, including support for additional document types, the implementation of content decoders, and enhancements to the application's error handling and dependency injection.

Support for additional document types:
* Updated `README.md` to indicate support for PDF, DOCX, and TXT files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18)
* Modified `VectorSearchService` to use content decoders for extracting document content based on file type. [[1]](diffhunk://#diff-8400148ad26b44e91661719a383f68db6a97736dda9b9e8e40113c813e1a4566L2-R22) [[2]](diffhunk://#diff-8400148ad26b44e91661719a383f68db6a97736dda9b9e8e40113c813e1a4566L129-L144)

Implementation of content decoders:
* Added `IContentDecoder` interface and implemented decoders for PDF, DOCX, and TXT files (`PdfContentDecoder`, `DocxContentDecoder`, `TextContentDecoder`). [[1]](diffhunk://#diff-30ce7c30934f90c3560a834fe6914995611c8e4fe880bddf22ecfd66e963cb18R1-R6) [[2]](diffhunk://#diff-89c38da5be5a2aa2551d7d879175db5c568635893219bd9e79fa088487740d7eR1-R24) [[3]](diffhunk://#diff-d2f263fce14e20fbdaaea3d662e88fb5be060ba64490a6a445410653f8f9b6b3R1-R25) [[4]](diffhunk://#diff-41483471b97afcdda2554f773b414a4ffed608b1d1e6191b29dcf6db840235ebR1-R12)

Enhancements to error handling:
* Enhanced the exception handling middleware to return specific status codes for `NotSupportedException` and other exceptions.

Dependency injection improvements:
* Registered content decoders with dependency injection using keyed services.

Other updates:
* Updated `SqlDatabaseVectorSearch.csproj` to include new package references for `DocumentFormat.OpenXml` and updated `Microsoft.SemanticKernel` to version 1.35.0. [[1]](diffhunk://#diff-e7398d7f8dfae605c7ae1ad25e55cb158534e6adb8db26f1727c19a68216025dR11) [[2]](diffhunk://#diff-e7398d7f8dfae605c7ae1ad25e55cb158534e6adb8db26f1727c19a68216025dL20-R21)

Closes #5 